### PR TITLE
Fix for switchbuf=useopen

### DIFF
--- a/plugin/zoomwintab.vim
+++ b/plugin/zoomwintab.vim
@@ -34,7 +34,10 @@ function! ZoomWinTabIn()
     if bufname('%') != ''
         let bufn = bufnr('%')
         let tabpage = tabpagenr()
+        let swbuf = &switchbuf
+        set switchbuf&
         exe 'tab sb '.bufn
+        let &switchbuf = swbuf
         if tabpage != tabpagenr()
             call settabvar(tabpagenr(),'zoomwintab',&stal)
             call settabvar(tabpagenr(),'zoomwintabnr',tabpage)


### PR DESCRIPTION
Temporarily resets the 'switchbuf' option so the buffer gets
opened in a new tab. I don't know if there is a cleaner way but this works for me.
