### PR TITLE
add option to hide tabbar on zoom

### DIFF
--- a/plugin/zoomwintab.vim
+++ b/plugin/zoomwintab.vim
@@ -17,6 +17,10 @@ set cpo&vim
 if !exists("g:zoomwintab_remap")
     let g:zoomwintab_remap = 1
 endif
+
+if !exists("g:zoomwintab_hidetabbar")
+    let g:zoomwintab_hidetabbar = 1
+endif
 " }}}
 
 
@@ -45,7 +49,9 @@ function! ZoomWinTabIn()
         if tabpage != tabpagenr()
             let t:zoomwintab = &stal
             let t:zoomwintabnr = tabpage
-            set showtabline=0
+            if g:zoomwintab_hidetabbar == 1
+                set showtabline=0
+            endif
         endif
     else
         echo 'No buffer'


### PR DESCRIPTION
By setting `g:zoomwintab_hidetabbar` the user can control tabbar hiding behavior.
With a value of `1` the tabbar will be hidden when zooming, a value of `0` won't.
Set by default to `1`