### PR TITLE
Simpler 'Already only one window' check

### DIFF
--- a/plugin/zoomwintab.vim
+++ b/plugin/zoomwintab.vim
@@ -35,7 +35,7 @@ function! ZoomWinTabIn()
         echo 'Already zoomed in'
         return
     endif
-    if tabpagewinnr(tabpagenr(),'$') == 1
+    if winnr('$') == 1
         echo 'Already only one window'
         return
     endif


### PR DESCRIPTION
The original implementation was querying for the current tab page number, then using that number to query for the number of windows on the currently visible tab.

This is entirely equivalent to using winnr to query for the number of currently visible windows. 