### PR TITLE
[add] airline extensions

### DIFF
--- a/autoload/airline/extensions/zoomwintab.vim
+++ b/autoload/airline/extensions/zoomwintab.vim
@@ -1,0 +1,27 @@
+" MIT License. Copyright (c) 2020 Dmitry Geurkov (d.geurkov@gmail.com)
+" Plugin: https://github.com/troydm/zoomwintab.vim
+" vim: et ts=2 sts=2 sw=2
+
+scriptencoding utf-8
+
+
+" Avoid installing twice
+if exists('g:loaded_vim_airline_zoomwintab')
+  finish
+endif
+
+let g:loaded_vim_airline_zoomwintab = 1
+
+let s:zoomwintab_status_zoomed_in =
+  \ get(g:, 'airline#extensions#zoomwintab#status_zoomed_in', g:airline_left_alt_sep.' Zoomed')
+let s:zoomwintab_status_zoomed_out =
+  \ get(g:, 'airline#extensions#zoomwintab#status_zoomed_out', '')
+
+function! airline#extensions#zoomwintab#apply(...) abort
+  call airline#extensions#prepend_to_section('gutter',
+    \ exists('t:zoomwintab') ? s:zoomwintab_status_zoomed_in : s:zoomwintab_status_zoomed_out)
+endfunction
+
+function! airline#extensions#zoomwintab#init(ext) abort
+  call a:ext.add_statusline_func('airline#extensions#zoomwintab#apply')
+endfunction

--- a/doc/zoomwintab.txt
+++ b/doc/zoomwintab.txt
@@ -1,4 +1,4 @@
-zoomwintab.vim for Vim version 7.0+   Last change: 11 February, 2013
+zoomwintab.vim for Vim version 7.0+   Last change: 10 April, 2020
 
 Maintainer: Dmitry "troydm" Geurkov <d.geurkov@gmail.com>
 Version: 0.1
@@ -12,7 +12,8 @@ Help on using zoomwintab.vim                                 *zoomwintab.vim*
 
 1. Introduction                    |zoomwintab.vim-intro|
 2. Configuration                   |zoomwintab.vim-configuration|
-2. Usage                           |zoomwintab.vim-usage|
+3. Usage                           |zoomwintab.vim-usage|
+4. Variables                       |zoomwintab.vim-variables|
 
 ============================================================================================
  1. INTRODUCTION                                                      *zoomwintab.vim-intro*
@@ -32,7 +33,7 @@ g:zoomwintab_hidetabbar (Default: 1)
     If enabled hides the tab bar
 
 ============================================================================================
- 2. USAGE                                                             *zoomwintab.vim-usage*
+ 3. USAGE                                                             *zoomwintab.vim-usage*
 
                                                                          *ZoomWinTabToggle*
 :ZoomWinTabToggle
@@ -45,5 +46,13 @@ g:zoomwintab_hidetabbar (Default: 1)
                                                                          *ZoomWinTabOut*
 :ZoomWinTabOut
     Zoom out current window
+
+============================================================================================
+ 4. VARIABLES                                                         *zoomwintab-variables*
+
+
+g:airline#extensions#anzu#enabled	*g:airline#extensions#zoomwintab#enabled*
+    Set whether to display search status information on |airline|.
+    Otherwise set to 0.
 
  vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
Hello, @troydm .

Thanks for writing airline's extenion patch about this plugin.

I added airline extension's script in this repo.
It works fine.
This eliminates the need for airline's PR.

> https://github.com/vim-airline/vim-airline/pull/2111

Could you check this PR?

## screenshot

<img width="1435" alt="スクリーンショット 2020-04-10 18 09 35" src="https://user-images.githubusercontent.com/36619465/78979432-d4740a80-7b56-11ea-8786-7fbd7c619e2c.png">

<img width="563" alt="スクリーンショット 2020-04-10 18 09 57" src="https://user-images.githubusercontent.com/36619465/78979451-dccc4580-7b56-11ea-9076-d306d91b21c9.png">
