### PR TITLE
Fixed toggleterm cursor return position

### DIFF
--- a/autoload/zoomwintab.vim
+++ b/autoload/zoomwintab.vim
@@ -59,13 +59,14 @@ function! zoomwintab#Out()
         echo 'Already zoomed out'
         return
     endif
-    let &stal = t:zoomwintab
     let tabpage = t:zoomwintabnr
+    let l:show_tab_line = t:zoomwintab
     tabclose
     if tabpagenr() != tabpage
         exe 'tabnext '.tabpage
     endif
     call zoomwintab#RefreshAirline()
+    let &stal = l:show_tab_line
     echo 'Zoomed Out'
 endfunction
 


### PR DESCRIPTION
Closes https://github.com/troydm/zoomwintab.vim/issues/15

Simply setting `    let &stal = l:show_tab_line` after all tab movements are completed is enough to keep the cursor position in the correct place. And this works for both a regular terminal & toggleterm buffer window.

## Before (Broken)
https://github.com/troydm/zoomwintab.vim/assets/10103049/044c1907-dbf5-4813-a5e8-97f578a52c10

## After (Fixed)
https://github.com/troydm/zoomwintab.vim/assets/10103049/28e2dba5-36ec-416d-974f-783a1b45ac6c